### PR TITLE
Clean (model names, AP principal, rawop, unused func)

### DIFF
--- a/config/llm_models.json
+++ b/config/llm_models.json
@@ -23,7 +23,11 @@
     },
     "mistral_medium": {
       "provider": "mistral",
-      "model_id": "mistral-medium-latest"
+      "model_id": "mistral-medium-2508"
+    },
+    "mistral_medium_3_5": {
+      "provider": "mistral",
+      "model_id": "mistral-medium-3.5"
     },
     "piag_mistral_medium": {
       "provider": "mte-piag",

--- a/ocapi/llm_utils/config.py
+++ b/ocapi/llm_utils/config.py
@@ -163,6 +163,8 @@ def _resolve_model_key(model: str | None, models_cfg: dict[str, Any]) -> str:
         "GPT5": "openai_gpt5",
         "GPT5mini": "openai_gpt5mini",
         "mte-api-piag-mistral-medium-latest": "piag_mistral_medium",
+        "mistral-medium-latest": "mistral_medium",
+        "mistral-large-latest": "mistral_large",
     }
     if model in legacy_aliases and legacy_aliases[model] in models:
         return legacy_aliases[model]

--- a/ocapi/step_detection/step_detection.py
+++ b/ocapi/step_detection/step_detection.py
@@ -60,6 +60,7 @@ def _parse_and_validate_raw_operations(
     raw_list = parse_llm_json_list_response(raw)
     raw_operations: list[RawOperation] = []
     for element in raw_list:
+        element["source_arrete"] = arrete_id
         try:
             raw_operations.append(RawOperation(**element))
         except Exception as exc:
@@ -212,7 +213,7 @@ def step_detection(arrete_file: ArreteFile) -> list[Operation]:
             )
 
         all_ops.extend(
-            _raw_operation_to_operation(html_block.page_content, raw_op, arrete_id, img_map)
+            _raw_operation_to_operation(html_block.page_content, raw_op, img_map)
             for raw_op in valid_operations
         )
     _LOGGER.info(f"Detection: {len(all_ops)} operation(s) detected")
@@ -222,7 +223,6 @@ def step_detection(arrete_file: ArreteFile) -> list[Operation]:
 def _raw_operation_to_operation(
     html_block: str,
     raw_operation: RawOperation,
-    source_arrete_id: ArreteId,
     img_map: ImageMap,
 ) -> Operation:
     """Extract the operand and sub-target for a raw detection and build the ``Operation``."""
@@ -248,7 +248,6 @@ def _raw_operation_to_operation(
 
     return Operation.from_raw_detection(
         raw_operation=raw_operation,
-        source_arrete_id=source_arrete_id,
         operation_id=operation_id,
         operand=operand,
         sub_target=sub_target,

--- a/ocapi/step_detection/step_detection_test.py
+++ b/ocapi/step_detection/step_detection_test.py
@@ -58,11 +58,11 @@ def test_convert_raw_operation_to_operation(
     mock_parse_subtarget.return_value = SubTarget(type=SubTargetType.TABLEAU, position=1)
 
     html_block = Document(page_content="<section>Test content</section>", metadata={})
-    source_arrete_id = "1980-01-01"
 
     raw_operations = [
         RawOperation(
             operation_type=RawOperationType.REPLACE,
+            source_arrete="1980-01-01",
             source_article="1",
             target_arrete="1981-01-01",
             target_article="2",
@@ -72,13 +72,14 @@ def test_convert_raw_operation_to_operation(
         ),
         RawOperation(
             operation_type=RawOperationType.REMOVE,
+            source_arrete="1980-01-01",
             source_article="2",
             target_arrete="1981-01-01",
             target_article="3",
         ),
     ]
     operations = [
-        _raw_operation_to_operation(html_block.page_content, raw_op, source_arrete_id, {})
+        _raw_operation_to_operation(html_block.page_content, raw_op, {})
         for raw_op in raw_operations
     ]
 
@@ -109,6 +110,7 @@ def test_convert_raw_operation_replace_all_refonte() -> None:
     html_block = Document(page_content="<section>Refonte complète</section>", metadata={})
     raw_op = RawOperation(
         operation_type=RawOperationType.REPLACE,
+        source_arrete="2021-09-24",
         source_article="1.1.2",
         target_arrete="2020-04-20",
         target_article="ALL",
@@ -117,7 +119,7 @@ def test_convert_raw_operation_replace_all_refonte() -> None:
         new_content_end_marker=None,
     )
 
-    operation = _raw_operation_to_operation(html_block.page_content, raw_op, "2021-09-24", {})
+    operation = _raw_operation_to_operation(html_block.page_content, raw_op, {})
 
     assert operation.operation_type == OperationType.REMOVE
     assert operation.source_id == NodeId(arrete_id="2021-09-24", article_id="1.1.2")
@@ -136,13 +138,14 @@ def test_all_with_non_full_section_subtarget_sets_error(
     )
     raw_op = RawOperation(
         operation_type=RawOperationType.REPLACE,
+        source_arrete="2025-02-10",
         source_article="5",
         target_arrete="2006-12-14",
         target_article="ALL",
         sub_target="annexe 1",
     )
     with caplog.at_level("WARNING"):
-        op = _raw_operation_to_operation("<section/>", raw_op, "2025-02-10", {})
+        op = _raw_operation_to_operation("<section/>", raw_op, {})
 
     assert ErrorCode.ERROR_EXTRACTING_OPERAND in op.error_codes
     assert any("not fully defined" in msg for msg in caplog.messages)
@@ -152,12 +155,13 @@ def test_all_with_full_section_subtarget_converts_to_remove() -> None:
     """target_article=ALL with FULL_SECTION sub-target is valid → REMOVE."""
     raw_op = RawOperation(
         operation_type=RawOperationType.REPLACE,
+        source_arrete="2021-09-24",
         source_article="1",
         target_arrete="2020-04-20",
         target_article="ALL",
         sub_target=None,
     )
-    op = _raw_operation_to_operation("<section/>", raw_op, "2021-09-24", {})
+    op = _raw_operation_to_operation("<section/>", raw_op, {})
 
     assert op.operation_type == OperationType.REMOVE
     assert op.error_codes == frozenset()
@@ -167,35 +171,38 @@ def test_all_with_full_section_subtarget_converts_to_remove() -> None:
 def test_raw_operation_to_operation_requires_source_article() -> None:
     raw = RawOperation(
         operation_type=RawOperationType.REMOVE,
+        source_arrete="2022-01-01",
         target_arrete="2021-01-01",
         source_article=None,
         target_article="1",
     )
     with pytest.raises(OperationError, match="source_article"):
-        _raw_operation_to_operation("<p/>", raw, "2022-01-01", {})
+        _raw_operation_to_operation("<p/>", raw, {})
 
 
 def test_raw_operation_to_operation_requires_target_article() -> None:
     raw = RawOperation(
         operation_type=RawOperationType.REMOVE,
+        source_arrete="2022-01-01",
         target_arrete="2021-01-01",
         source_article="1",
         target_article=None,
     )
     with pytest.raises(OperationError, match="target_article"):
-        _raw_operation_to_operation("<p/>", raw, "2022-01-01", {})
+        _raw_operation_to_operation("<p/>", raw, {})
 
 
 def test_add_all_without_subtarget_flagged_as_not_an_operation() -> None:
     """ADD + target_article=ALL without sub_target is not a consolidation op."""
     raw_op = RawOperation(
         operation_type=RawOperationType.ADD,
+        source_arrete="2010-12-24",
         source_article="1",
         target_arrete="2008-12-10",
         target_article="ALL",
         sub_target=None,
     )
-    op = _raw_operation_to_operation("<section/>", raw_op, "2010-12-24", {})
+    op = _raw_operation_to_operation("<section/>", raw_op, {})
 
     assert op.operation_type == OperationType.ADD
     assert ErrorCode.NOT_AN_OPERATION in op.error_codes
@@ -209,12 +216,13 @@ def test_add_all_with_full_section_subtarget_flagged_as_not_an_operation(
     mock_parse_subtarget.return_value = SubTarget(type=SubTargetType.FULL_SECTION)
     raw_op = RawOperation(
         operation_type=RawOperationType.ADD,
+        source_arrete="2010-12-24",
         source_article="1",
         target_arrete="2008-12-10",
         target_article="ALL",
         sub_target="ALL",
     )
-    op = _raw_operation_to_operation("<section/>", raw_op, "2010-12-24", {})
+    op = _raw_operation_to_operation("<section/>", raw_op, {})
 
     assert ErrorCode.NOT_AN_OPERATION in op.error_codes
 
@@ -229,12 +237,13 @@ def test_add_all_with_partial_subtarget_is_an_operation(
     )
     raw_op = RawOperation(
         operation_type=RawOperationType.ADD,
+        source_arrete="2010-12-24",
         source_article="1",
         target_arrete="2008-12-10",
         target_article="ALL",
         sub_target="annexe 1",
     )
-    op = _raw_operation_to_operation("<section/>", raw_op, "2010-12-24", {})
+    op = _raw_operation_to_operation("<section/>", raw_op, {})
 
     assert ErrorCode.ERROR_EXTRACTING_OPERAND in op.error_codes
     assert ErrorCode.NOT_AN_OPERATION not in op.error_codes
@@ -266,12 +275,13 @@ def test_convert_raw_operation_propagates_confidence_score(
     mock_extract.return_value = None
     raw_op = RawOperation(
         operation_type=RawOperationType.REMOVE,
+        source_arrete="2022-01-01",
         source_article="1",
         target_arrete="2021-01-01",
         target_article="2",
         confidence_score=85,
     )
-    op = _raw_operation_to_operation("<section/>", raw_op, "2022-01-01", {})
+    op = _raw_operation_to_operation("<section/>", raw_op, {})
     assert op.confidence_score == 85
 
 
@@ -282,11 +292,12 @@ def test_convert_raw_operation_confidence_score_none_when_absent(
     mock_extract.return_value = None
     raw_op = RawOperation(
         operation_type=RawOperationType.REMOVE,
+        source_arrete="2022-01-01",
         source_article="1",
         target_arrete="2021-01-01",
         target_article="2",
     )
-    op = _raw_operation_to_operation("<section/>", raw_op, "2022-01-01", {})
+    op = _raw_operation_to_operation("<section/>", raw_op, {})
     assert op.confidence_score is None
 
 

--- a/ocapi/step_rendering/main_content_test.py
+++ b/ocapi/step_rendering/main_content_test.py
@@ -255,7 +255,7 @@ def test_make_section_version_full_remove_marks_abrogated() -> None:
 
 def test_make_permit_content_renders_full_main_with_section_versions() -> None:
     """Layout / section_version behaviour; kept for future refonte of permit HTML."""
-    ap_initial = make_testing_arrete(
+    principal_arrete = make_testing_arrete(
         arrete_id="2020-01-01",
         aiot="0001",
         filename="ap_initial",
@@ -295,7 +295,7 @@ def test_make_permit_content_renders_full_main_with_section_versions() -> None:
 
     html = make_permit_content(
         history=history,
-        arrete=ap_initial,
+        arrete=principal_arrete,
         operations=[op_replace],
     )
 
@@ -390,7 +390,7 @@ def test_make_permit_content_renders_all_versions_for_complementary_arrete() -> 
 
 def test_make_permit_content_inserts_new_article_after_predecessor() -> None:
     """NEW_ARTICLE sections are inserted after the greatest existing article id below them."""
-    ap_initial = make_testing_arrete(
+    principal_arrete = make_testing_arrete(
         arrete_id="2020-01-01",
         aiot="0001",
         filename="ap_initial",
@@ -428,7 +428,7 @@ def test_make_permit_content_inserts_new_article_after_predecessor() -> None:
     )
     html = make_permit_content(
         history=history,
-        arrete=ap_initial,
+        arrete=principal_arrete,
         operations=[op_create],
     )
     assert html.index("Article 1 initial") < html.index("Article 2 inséré")

--- a/ocapi/step_rendering/other.py
+++ b/ocapi/step_rendering/other.py
@@ -49,7 +49,7 @@ def make_permit_other(
     arrete_files: list[ArreteFile],
     operations: list[Operation],
     history: ArticleHistory | None = None,
-    ap_principal_id: str | None = None,
+    principal_arrete_id: str | None = None,
 ) -> str:
     """Generate the HTML sections for complementary and modifying arrêtés.
 
@@ -68,15 +68,15 @@ def make_permit_other(
     history : ArticleHistory | None
         Article version history, used to determine operation resolution status
         and to consolidate per-arrêté article versions.
-    ap_principal_id : str | None
-        Id of the principal AP, which is excluded from this section. Falls
+    principal_arrete_id : str | None
+        Id of the principal arrêté, which is excluded from this section. Falls
         back to ``arrete_files[0].id`` when not provided.
     """
     complement_sections: list[str] = []
     modifying_sections: list[str] = []
     skip_id = (
-        ap_principal_id
-        if ap_principal_id is not None
+        principal_arrete_id
+        if principal_arrete_id is not None
         else (arrete_files[0].id if arrete_files else None)
     )
 

--- a/ocapi/step_rendering/other_test.py
+++ b/ocapi/step_rendering/other_test.py
@@ -26,7 +26,7 @@ _EMPTY_AP = '<html><body data-arretify_version="0.2.0"><main data-spec="main"></
 
 
 def test_make_permit_other_contains_only_non_consolidated_complements() -> None:
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     complement_no_ops = make_testing_arrete(
         "2021-01-01",
         """
@@ -57,7 +57,7 @@ def test_make_permit_other_contains_only_non_consolidated_complements() -> None:
         )
     ]
 
-    html = make_permit_other([ap_initial, complement_no_ops, complement_with_ops], operations)
+    html = make_permit_other([principal_arrete, complement_no_ops, complement_with_ops], operations)
 
     assert 'data-spec="permit_complements"' in html
     assert 'data-spec="permit_complement"' in html
@@ -69,7 +69,7 @@ def test_make_permit_other_contains_only_non_consolidated_complements() -> None:
 
 def test_make_permit_other_includes_modifying_arretes_with_operation_messages() -> None:
     """Modifying arrêtés appear with operation result messages in source articles."""
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     modifying = make_testing_arrete(
         "2022-01-01",
         """
@@ -101,7 +101,7 @@ def test_make_permit_other_includes_modifying_arretes_with_operation_messages() 
         ],
     }
 
-    html = make_permit_other([ap_initial, modifying], [op], history=history)
+    html = make_permit_other([principal_arrete, modifying], [op], history=history)
 
     assert 'data-spec="permit_modifying"' in html
     assert "ID MOD" in html
@@ -119,7 +119,7 @@ def test_make_permit_other_includes_modifying_arretes_with_operation_messages() 
 
 def test_make_permit_other_shows_unresolved_message_for_failed_operation() -> None:
     """Unresolved operations get a reason in source article messages."""
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     modifying = make_testing_arrete(
         "2022-01-01",
         """
@@ -151,7 +151,7 @@ def test_make_permit_other_shows_unresolved_message_for_failed_operation() -> No
         ],
     }
 
-    html = make_permit_other([ap_initial, modifying], [op], history=history)
+    html = make_permit_other([principal_arrete, modifying], [op], history=history)
 
     assert "Opération de consolidation non résolue" in html
     assert "l'article 5 de l'arrêté 2020-01-01" in html
@@ -160,7 +160,7 @@ def test_make_permit_other_shows_unresolved_message_for_failed_operation() -> No
 
 def test_make_permit_other_skips_abrogated_modifying_arrete() -> None:
     """Abrogated modifying arrêtés are not displayed."""
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     abrogated = make_testing_arrete(
         "2022-01-01",
         """
@@ -179,14 +179,14 @@ def test_make_permit_other_skips_abrogated_modifying_arrete() -> None:
         operation_type=OperationType.REPLACE,
     )
 
-    html = make_permit_other([ap_initial, abrogated], [op], history={})
+    html = make_permit_other([principal_arrete, abrogated], [op], history={})
 
     assert html == ""
 
 
 def test_target_all_shows_arrete_only() -> None:
     """Target article_id=ALL displays only the arrêté reference, no article number."""
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     modifying = make_testing_arrete(
         "2022-01-01",
         """
@@ -218,7 +218,7 @@ def test_target_all_shows_arrete_only() -> None:
         ],
     }
 
-    html = make_permit_other([ap_initial, modifying], [op], history=history)
+    html = make_permit_other([principal_arrete, modifying], [op], history=history)
 
     assert "l'arrêté 2020-01-01" in html
     assert "l'article ALL" not in html
@@ -226,7 +226,7 @@ def test_target_all_shows_arrete_only() -> None:
 
 def test_make_permit_other_includes_appendix_with_operation_messages() -> None:
     """Operations sourced from an appendix article get a message inside the appendix."""
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     modifying = make_testing_arrete(
         "2022-01-01",
         """
@@ -261,7 +261,7 @@ def test_make_permit_other_includes_appendix_with_operation_messages() -> None:
         ],
     }
 
-    html = make_permit_other([ap_initial, modifying], [op], history=history)
+    html = make_permit_other([principal_arrete, modifying], [op], history=history)
 
     assert 'data-spec="permit_modifying"' in html
     assert 'data-spec="appendix"' in html
@@ -277,7 +277,7 @@ def test_make_permit_other_includes_appendix_with_operation_messages() -> None:
 
 def test_target_new_article_strips_prefix() -> None:
     """Target article_id=NEW_ARTICLE:4.1 renders as 'l'article 4.1'."""
-    ap_initial = make_testing_arrete("2020-01-01", _EMPTY_AP)
+    principal_arrete = make_testing_arrete("2020-01-01", _EMPTY_AP)
     modifying = make_testing_arrete(
         "2022-01-01",
         """
@@ -308,7 +308,7 @@ def test_target_new_article_strips_prefix() -> None:
         ],
     }
 
-    html = make_permit_other([ap_initial, modifying], [op], history=history)
+    html = make_permit_other([principal_arrete, modifying], [op], history=history)
 
     assert "l'article 4.1" in html
     assert "NEW_ARTICLE" not in html

--- a/ocapi/step_rendering/step_rendering.py
+++ b/ocapi/step_rendering/step_rendering.py
@@ -28,7 +28,7 @@ from ocapi.utils.logging_utils import get_logger
 _LOGGER = get_logger(__name__)
 
 
-def _select_principal_ap(arrete_files: list[ArreteFile]) -> ArreteFile:
+def _select_principal_arrete(arrete_files: list[ArreteFile]) -> ArreteFile:
     """Pick the arrêté to use as the consolidation base.
 
     Honours a user-provided ``principal`` flag when set (exactly one arrêté
@@ -79,14 +79,14 @@ def step_rendering(
         Object containing the HTML of the header, main content and complements.
     """
     _LOGGER.info(f"Rendering: generating permit from {len(history)} modified article(s)")
-    ap_principal = _select_principal_ap(arrete_files)
-    contenu_permis = make_permit_content(history, ap_principal, operations)
+    principal_arrete = _select_principal_arrete(arrete_files)
+    contenu_permis = make_permit_content(history, principal_arrete, operations)
     header_permis = make_permit_header(arrete_files)
     other_permis = make_permit_other(
         arrete_files,
         operations=operations,
         history=history,
-        ap_principal_id=ap_principal.id,
+        principal_arrete_id=principal_arrete.id,
     )
     _LOGGER.debug("Rendering: permit generated successfully")
     return Permis(header=header_permis, contenu=contenu_permis, other=other_permis)

--- a/ocapi/step_rendering/step_rendering_test.py
+++ b/ocapi/step_rendering/step_rendering_test.py
@@ -22,7 +22,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ocapi.exceptions import OcapiError
-from ocapi.step_rendering.step_rendering import _select_principal_ap, permis_to_html, step_rendering
+from ocapi.step_rendering.step_rendering import (
+    _select_principal_arrete,
+    permis_to_html,
+    step_rendering,
+)
 from ocapi.types import ArreteFile, ArticleHistory, FileType, Operation, Permis
 from ocapi.utils.testing import make_testing_arrete
 
@@ -46,7 +50,7 @@ def test_step_rendering_returns_permis(
     mock_content.assert_called_once_with(history, arrete, operations)
     mock_header.assert_called_once_with(arretes)
     mock_other.assert_called_once_with(
-        arretes, operations=operations, history=history, ap_principal_id=arrete.id
+        arretes, operations=operations, history=history, principal_arrete_id=arrete.id
     )
 
     assert isinstance(result, Permis)
@@ -55,15 +59,15 @@ def test_step_rendering_returns_permis(
     assert result.other == "<other/>"
 
 
-class TestSelectPrincipalAp:
-    """Cover the principal AP selection and flag marking."""
+class TestSelectPrincipalArrete:
+    """Cover the principal arrêté selection and flag marking."""
 
     def test_principal_flag_overrides_heuristic(self) -> None:
         older = make_testing_arrete("2018-01-01", file_type=FileType.AP_AUTORISATION)
         refonte = make_testing_arrete("2022-01-01", file_type=FileType.AP_AUTORISATION)
         older.principal = True
 
-        assert _select_principal_ap([older, refonte]) is older
+        assert _select_principal_arrete([older, refonte]) is older
 
     def test_multiple_principals_raise(self) -> None:
         first = make_testing_arrete("2018-01-01")
@@ -72,13 +76,13 @@ class TestSelectPrincipalAp:
         second.principal = True
 
         with pytest.raises(OcapiError):
-            _select_principal_ap([first, second])
+            _select_principal_arrete([first, second])
 
     def test_inferred_principal_is_marked(self) -> None:
         older = make_testing_arrete("2018-01-01", file_type=FileType.AP_AUTORISATION)
         refonte = make_testing_arrete("2022-01-01", file_type=FileType.AP_AUTORISATION)
 
-        chosen = _select_principal_ap([older, refonte])
+        chosen = _select_principal_arrete([older, refonte])
 
         assert chosen is refonte
         assert refonte.principal is True

--- a/ocapi/step_resolution/apply_ops.py
+++ b/ocapi/step_resolution/apply_ops.py
@@ -50,7 +50,6 @@ from ocapi.types import (
     OperationId,
     OperationType,
     SubTargetType,
-    _to_operation_type,
     article_display_number,
 )
 from ocapi.utils.logging_utils import get_logger
@@ -89,17 +88,15 @@ def _edge_to_operation(
 ) -> Operation:
     """Convert a graph edge into an Operation instance."""
     data = operations_graph[src][tgt][key]
-    op_type = _to_operation_type(data["operation_type"])
-    operation = Operation(
+    return Operation(
         id=data["id"],
         source_id=src,
         target_id=tgt,
-        operation_type=op_type,
+        operation_type=OperationType(data["operation_type"]),
         operand=data.get("operand", None),
         sub_target=data.get("sub_target", None),
         error_codes=data.get("error_codes") or frozenset(),
     )
-    return operation
 
 
 def _strip_duplicate_section_title(

--- a/ocapi/types.py
+++ b/ocapi/types.py
@@ -406,6 +406,7 @@ class PermitComplements(_BaseModelWithConfig):
 
 class RawOperation(_BaseModelWithConfig):
     operation_type: RawOperationType
+    source_arrete: ArreteId
     source_article: str | None = None
     target_arrete: str
     target_article: str | None = None
@@ -508,7 +509,6 @@ class Operation(_BaseModelWithConfig):
     def from_raw_detection(
         cls,
         raw_operation: RawOperation,
-        source_arrete_id: ArreteId,
         operation_id: OperationId,
         operand: str | None,
         sub_target: "SubTarget | None",
@@ -537,7 +537,7 @@ class Operation(_BaseModelWithConfig):
         return cls(
             id=operation_id,
             source_id=NodeId(
-                arrete_id=source_arrete_id,
+                arrete_id=raw_operation.source_arrete,
                 article_id=raw_operation.source_article,
             ),
             target_id=NodeId(
@@ -554,14 +554,6 @@ class Operation(_BaseModelWithConfig):
 def is_resolved_op(operation: "Operation") -> bool:
     """Return True when no error is attached to *operation*."""
     return not operation.error_codes
-
-
-def _to_operation_type(raw_type: OperationType | str) -> OperationType:
-    """Ensure we always work with an OperationType instance."""
-    if isinstance(raw_type, OperationType):
-        return raw_type
-    raw_str = getattr(raw_type, "value", raw_type)
-    return OperationType(raw_str)
 
 
 def categorize_arrete(filename: str) -> FileType:

--- a/ocapi/utils/tagging_io.py
+++ b/ocapi/utils/tagging_io.py
@@ -133,6 +133,7 @@ def _operation_tag_to_raw_operations(
     return [
         RawOperation(
             operation_type=operation_type,
+            source_arrete=arrete_id,
             source_article=source_article,
             target_arrete=target_arrete,
             target_article=target_article,

--- a/ocapi/utils/testing.py
+++ b/ocapi/utils/testing.py
@@ -77,10 +77,15 @@ def make_testing_arrete(
 
 
 def make_testing_raw_op(
-    score: int | None, source: str = "1", target: str = "2", target_arrete: str = "2021-01-01"
+    score: int | None,
+    source: str = "1",
+    target: str = "2",
+    source_arrete: str = "1980-01-01",
+    target_arrete: str = "2021-01-01",
 ) -> RawOperation:
     return RawOperation(
         operation_type=RawOperationType.REPLACE,
+        source_arrete=source_arrete,
         source_article=source,
         target_arrete=target_arrete,
         target_article=target,

--- a/scripts/evaluate_detection.py
+++ b/scripts/evaluate_detection.py
@@ -61,8 +61,9 @@ _VALID_OP_TYPES = {"ADD", "REPLACE", "REMOVE"}
 
 # Cost per 1M tokens (USD): {model_id: (input_cost, output_cost)}
 _COST_PER_1M_TOKENS: dict[str, tuple[float, float]] = {
-    "mistral-medium-latest": (0.40, 2.00),
-    "mistral-large-latest": (0.50, 1.50),
+    "mistral-medium-2508": (0.40, 2.00),
+    "mistral-medium-3.5": (1.50, 7.50),
+    "mistral-large-2512": (0.50, 1.50),
     "gpt-4o": (2.50, 10.00),
     "gpt-5": (1.25, 10.00),
     "gpt-5-mini": (0.25, 2.00),


### PR DESCRIPTION
Closes #117.

## Résumé

### Modèles Mistral
- Renomme `mistral-medium-latest` → `mistral-medium-2508` et `mistral-large-latest` → `mistral-large-2512` dans `config/llm_models.json`.
- Ajoute un endpoint `mistral_medium_3_5` (`mistral-medium-3.5`), avec ses coûts (1.50$ / 7.50$) dans `scripts/evaluate_detection.py`.
- Ajoute les alias legacy (`mistral-medium-latest`, `mistral-large-latest`) dans `ocapi/llm_utils/config.py` pour compat ascendante.

### Renommages AP principal
- `_select_principal_ap` → `_select_principal_arrete` (et call sites).
- Paramètre `ap_principal_id` de `make_permit_other` → `principal_arrete_id`.
- Variables `ap_initial` dans les tests renommées en `principal_arrete` (string literals comme `filename="ap_initial"` laissés tels quels).

### RawOperation.source_arrete
- Ajoute le champ `source_arrete: ArreteId` à `RawOperation`.
- Supprime le paramètre `source_arrete_id` de `_raw_operation_to_operation` et de `Operation.from_raw_detection` — la valeur est lue depuis `raw_operation.source_arrete`.
- Injection explicite de `element["source_arrete"] = arrete_id` dans `_parse_and_validate_raw_operations` avant l'instanciation Pydantic (à cause de `extra="forbid"`).
- `make_testing_raw_op` accepte un paramètre `source_arrete` optionnel.

### Dead code
- Supprime `_to_operation_type` de `types.py` ; le seul appelant (`apply_ops._operation_from_data`) coerce directement via `OperationType(data["operation_type"])`.

## Tests

- 462 tests OK.
- Mise à jour des `RawOperation(...)` et appels à `_raw_operation_to_operation` dans `step_detection_test.py` pour inclure `source_arrete`.