### PR TITLE
Fix: config LLM et tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 # Configuration LLM
 # =============================================================================
 
+# Override la cle primary_model_key / secondary_model_key de config/llm_models.json
+# La valeur doit correspondre a une cle definie dans le bloc "models".
+# LLM_PRIMARY_MODEL_KEY=piag_mistral_medium
+# LLM_SECONDARY_MODEL_KEY=
+
 # PIAG API (defaut pour le MTE)
 LLM__PIAG_API_KEY=
 LLM__PIAG_API_URL=https://preprod.api.piag.din.gouv.fr/v1/chat/completions

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ log_level = settings.logging.level
 La sélection de modèle, le retry, le timeout et le rate limiting sont centralisés
 dans des fichiers JSON sous `config/` :
 
-- `config/llm_models.json` (`primary_model_key`, `secondary_model_key`, `models`)
+- `config/llm_models.json` (`primary_model_key`, `secondary_model_key`, `models`) ;
+  surchargeable sans toucher au JSON via `LLM_PRIMARY_MODEL_KEY` et
+  `LLM_SECONDARY_MODEL_KEY` dans le `.env`
 - `config/llm_resilience.json` (`timeout_seconds`, stratégie de retry/fallback)
 - `config/llm_rate_limit.json` (throttling optionnel)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,11 @@ Providers supportés : `mte-piag`, `mistral`, `openai`, `anthropic`, `google`.
 `reasoning_model: true` change le payload OpenAI (passe `reasoning_effort: high`
 + `verbosity: low` au lieu de `temperature`).
 
+`primary_model_key` et `secondary_model_key` peuvent être surchargés sans
+toucher au JSON via les variables d'environnement `LLM_PRIMARY_MODEL_KEY` et
+`LLM_SECONDARY_MODEL_KEY` (la valeur doit correspondre à une `model_key`
+déclarée dans `models`).
+
 ### `config/llm_resilience.json`
 
 ```json

--- a/ocapi/cli_test.py
+++ b/ocapi/cli_test.py
@@ -196,7 +196,10 @@ def test_cli_tagged_output_is_forwarded(
 @patch("ocapi.cli.run_pipeline")
 @patch("ocapi.cli.load_document_contexts")
 def test_run_main_principal_id_flags_matching_arrete(
-    mock_load: MagicMock, mock_pipeline: MagicMock, _mock_save: MagicMock
+    mock_load: MagicMock,
+    mock_pipeline: MagicMock,
+    _mock_save: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """--principal-id marks the matching arrêté before the pipeline runs."""
     arretes = [make_testing_arrete("2020-01-01"), make_testing_arrete("2024-09-27")]
@@ -204,7 +207,7 @@ def test_run_main_principal_id_flags_matching_arrete(
     mock_pipeline.return_value = ([], {}, arretes, None)
 
     exit_code = run_main(
-        Path("ignored"),
+        tmp_path,
         enable_rendering=False,
         principal_id="2024-09-27",
     )
@@ -217,13 +220,15 @@ def test_run_main_principal_id_flags_matching_arrete(
 @patch("ocapi.cli.run_pipeline")
 @patch("ocapi.cli.load_document_contexts")
 def test_run_main_principal_id_missing_returns_error(
-    mock_load: MagicMock, mock_pipeline: MagicMock
+    mock_load: MagicMock,
+    mock_pipeline: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """--principal-id with no matching arrêté returns exit code 1 and skips the pipeline."""
     mock_load.return_value = [(make_testing_arrete("2020-01-01"), MagicMock())]
 
     exit_code = run_main(
-        Path("ignored"),
+        tmp_path,
         enable_rendering=False,
         principal_id="2030-01-01",
     )

--- a/ocapi/llm_utils/config.py
+++ b/ocapi/llm_utils/config.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -140,6 +141,29 @@ def _primary_secondary_keys(models_cfg: dict[str, Any]) -> tuple[str, str | None
         primary = next(iter(models.keys()))
     if not isinstance(secondary, str) or secondary not in models:
         secondary = None
+
+    env_primary = os.environ.get("LLM_PRIMARY_MODEL_KEY", "").strip()
+    if env_primary:
+        if env_primary in models:
+            primary = env_primary
+        else:
+            _LOGGER.warning(
+                "LLM_PRIMARY_MODEL_KEY=%r not found in llm_models.json; keeping %r.",
+                env_primary,
+                primary,
+            )
+
+    env_secondary = os.environ.get("LLM_SECONDARY_MODEL_KEY", "").strip()
+    if env_secondary:
+        if env_secondary in models:
+            secondary = env_secondary
+        else:
+            _LOGGER.warning(
+                "LLM_SECONDARY_MODEL_KEY=%r not found in llm_models.json; keeping %r.",
+                env_secondary,
+                secondary,
+            )
+
     return primary, secondary
 
 

--- a/ocapi/llm_utils/config_test.py
+++ b/ocapi/llm_utils/config_test.py
@@ -18,6 +18,8 @@
 #
 from unittest.mock import patch
 
+import pytest
+
 from ocapi.llm_utils import config_model_llm
 
 
@@ -49,3 +51,62 @@ def test_config_model_llm_uses_primary_and_secondary_keys() -> None:
     assert primary.model_name == "gpt-5"
     assert secondary.provider == "mte-piag"
     assert secondary.model_name == "mte-api-piag-mistral-medium-latest"
+
+
+def _fake_models_cfg() -> dict[str, object]:
+    return {
+        "primary_model_key": "openai_primary",
+        "secondary_model_key": "mistral_secondary",
+        "models": {
+            "openai_primary": {"provider": "openai", "model_id": "gpt-5"},
+            "mistral_secondary": {
+                "provider": "mte-piag",
+                "model_id": "mte-api-piag-mistral-medium-latest",
+            },
+            "anthropic_alt": {"provider": "anthropic", "model_id": "claude-opus-4-6"},
+        },
+    }
+
+
+def test_env_overrides_primary_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM_PRIMARY_MODEL_KEY replaces the JSON-configured primary."""
+    monkeypatch.setenv("LLM_PRIMARY_MODEL_KEY", "anthropic_alt")
+    with patch("ocapi.llm_utils.config._load_llm_models_config", return_value=_fake_models_cfg()):
+        with patch(
+            "ocapi.llm_utils.config._provider_api_config",
+            return_value=("anthropic-key", "https://anthropic.example"),
+        ):
+            primary = config_model_llm()
+
+    assert primary.model_key == "anthropic_alt"
+    assert primary.provider == "anthropic"
+
+
+def test_env_overrides_secondary_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM_SECONDARY_MODEL_KEY replaces the JSON-configured secondary."""
+    monkeypatch.setenv("LLM_SECONDARY_MODEL_KEY", "anthropic_alt")
+    with patch("ocapi.llm_utils.config._load_llm_models_config", return_value=_fake_models_cfg()):
+        with patch(
+            "ocapi.llm_utils.config._provider_api_config",
+            return_value=("anthropic-key", "https://anthropic.example"),
+        ):
+            secondary = config_model_llm("secondary")
+
+    assert secondary.model_key == "anthropic_alt"
+
+
+def test_unknown_env_model_key_is_ignored_with_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A bogus LLM_PRIMARY_MODEL_KEY falls back to the configured primary and logs."""
+    monkeypatch.setenv("LLM_PRIMARY_MODEL_KEY", "does_not_exist")
+    with patch("ocapi.llm_utils.config._load_llm_models_config", return_value=_fake_models_cfg()):
+        with patch(
+            "ocapi.llm_utils.config._provider_api_config",
+            return_value=("openai-key", "https://openai.example"),
+        ):
+            with caplog.at_level("WARNING"):
+                primary = config_model_llm()
+
+    assert primary.model_key == "openai_primary"
+    assert any("does_not_exist" in msg for msg in caplog.messages)


### PR DESCRIPTION
Closes #122.

## Résumé

### Override via env
- `LLM_PRIMARY_MODEL_KEY` / `LLM_SECONDARY_MODEL_KEY` surchargent `primary_model_key` / `secondary_model_key` de `config/llm_models.json` sans toucher au JSON.
- La valeur doit correspondre à une clé déclarée dans `models` ; sinon on garde la valeur du JSON et on log un warning.
- Doc dans `.env.example`, `docs/configuration.md`, `README.md`.

### Tests
- `cli_test.py` : `test_run_main_principal_id_flags_matching_arrete` et `test_run_main_principal_id_missing_returns_error` passent à `tmp_path` au lieu de `Path("ignored")` (plus de dossier `ignored/` créé à côté du repo pendant les tests).
- 3 nouveaux tests dans `llm_utils/config_test.py` : override primary, override secondary, fallback + warning si clé inconnue.

## Tests

465 tests OK.