### PR TITLE
Mark all operations on non-existing arrêtés as MISSING_ARRETE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ htmlcov/
 # Cursor (règles locales, ne pas versionner)
 .cursor/
 
+# GitHub Copilot (règles locales, ne pas versionner)
+.github/copilot-instructions.md
+
 # Artefacts locaux
 ocapi_architecture.html
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -26,7 +26,7 @@ explicite (`ERROR_CODE_MESSAGES`, en français).
 | `disabled_llm_call` | resolution (sous-cible complexe + `enable_llm=False`) | oui | La résolution complexe par IA est désactivée (mode snapshot ou opt-out). |
 | `propagated_error` | resolution (`apply_ops`) | oui | Une opération précédente sur le même article était en erreur. |
 | `less_important` | resolution (`build_graph`) | oui | Abrogation totale écartée car d'autres opérations plus précises ciblent le même arrêté. |
-| `missing_arrete` | resolution (`build_graph`) | oui | Abrogation totale visant un arrêté absent du permis (souvent un texte antérieur non inclus). |
+| `missing_arrete` | resolution (`build_graph`) | oui | Toute opération visant un arrêté absent du permis (abrogation totale ou opération article-par-article sur un texte non inclus). |
 
 ## Détail par code
 
@@ -137,13 +137,14 @@ présente d'autres opérations qui rendent celle-ci caduque ».
 
 ### `missing_arrete`
 
-**Posé par :** `build_graph` quand une abrogation totale (REMOVE/REPLACE ALL)
-cible un arrêté qui ne figure pas dans le permis consolidé (typiquement un
-texte antérieur non récupéré).
+**Posé par :** `build_graph` quand **toute opération** (abrogation totale
+REMOVE/REPLACE ALL, ou opération ciblant un article précis) vise un arrêté
+qui ne figure pas dans le permis consolidé (typiquement un texte antérieur
+non récupéré).
 
 **Effet :** l'opération n'est pas appliquée et n'ajoute aucun nœud au graphe.
 Le permis affichera « L'arrêté cible n'est pas présent dans le permis
-consolidé » pour signaler qu'il n'y a rien à abroger côté permis.
+consolidé » pour signaler qu'il n'y a pas de cible disponible dans le permis.
 
 ## Helpers
 

--- a/docs/pipeline-steps/resolution.md
+++ b/docs/pipeline-steps/resolution.md
@@ -36,13 +36,18 @@ flowchart LR
 [`build_graph`](https://github.com/mte-dgpr/ocapi/blob/main/ocapi/step_resolution/build_op_graph.py)
 parcourt les opérations dans l'ordre fourni (chronologique par `arrete_id`) :
 
-- **Abrogation totale** (`REMOVE` ou `REPLACE` avec `target_article = "ALL"`
-  et `sub_target = FULL_SECTION`, sans `error_codes`) → l'arrêté cible passe
-  à `status = False`. Cas spécial : si la cible est l'arrêté `principal`,
-  l'opération est rejetée avec `ERROR_EXTRACTING_TARGET` (vraisemblablement
-  une fausse détection).
-- **Cible introuvable** (arrêté `target` non chargé) → l'opération est
-  ignorée et trackée dans `skipped_ops`.
+- **Abrogation totale réussie** (`REMOVE` ou `REPLACE` avec
+  `target_article = "ALL"`, `sub_target = FULL_SECTION`, sans `error_codes`)
+  → l'arrêté cible passe à `status = False`.
+- **Abrogation totale rejetée** — trois sous-cas, tous trackés dans
+  `skipped_ops` avec la raison :
+    - cible = arrêté `principal` → `ERROR_EXTRACTING_TARGET`
+      (vraisemblablement une fausse détection) ;
+    - même source cible déjà le même arrêté avec des opérations plus précises
+      → `LESS_IMPORTANT` (abrogation écartée) ;
+    - arrêté cible absent du permis → `MISSING_ARRETE`.
+- **Cible introuvable sur une opération article-par-article** (arrêté `target`
+  non chargé) → marqué `MISSING_ARRETE` et tracké dans `skipped_ops`.
 - **Section cible/source introuvable** dans le HTML → un nœud vide est
   créé et l'opération est marquée `ERROR_EXTRACTING_TARGET` /
   `ERROR_EXTRACTING_SOURCE` ; elle restera dans le graphe pour traçabilité

--- a/ocapi/snapshot_test.py
+++ b/ocapi/snapshot_test.py
@@ -80,10 +80,14 @@ def test_snapshot_pipeline_output(
         snapshot_dir.mkdir(parents=True, exist_ok=True)
         for filename, data in [("operations.json", ops_json), ("history.json", history_json)]:
             (snapshot_dir / filename).write_text(
-                json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8"
+                json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+                newline="\n",
             )
         if permis_html:
-            (snapshot_dir / "permis.html").write_text(normalize_html(permis_html), encoding="utf-8")
+            (snapshot_dir / "permis.html").write_text(
+                normalize_html(permis_html), encoding="utf-8", newline="\n"
+            )
         pytest.skip("Snapshots updated. Run without UPDATE_SNAPSHOTS=1 to verify.")
 
     if not snapshot_dir.exists():

--- a/ocapi/step_resolution/build_op_graph.py
+++ b/ocapi/step_resolution/build_op_graph.py
@@ -248,13 +248,14 @@ def build_graph(
             if target_soup is None:
                 error_msg = f"Operation {op.id}: arrêté {op.target_id.arrete_id} not found in files"
                 _LOGGER.warning(error_msg)
-                op = op.model_copy(
+                updated_op = op.model_copy(
                     update={"error_codes": op.error_codes | {ErrorCode.MISSING_ARRETE}}
                 )
-                skipped_ops.append((op, error_msg))
-                updated_ops.append(op)
+                skipped_ops.append((updated_op, error_msg))
+                updated_ops.append(updated_op)
                 continue
 
+            updated_op = op
             try:
                 target_title, target_content = get_node_content(op.target_id, target_soup)
             except SectionNotFoundError:
@@ -265,7 +266,7 @@ def build_graph(
                     op.target_id,
                 )
                 target_title, target_content = "", ""
-                op = op.model_copy(
+                updated_op = op.model_copy(
                     update={"error_codes": op.error_codes | {ErrorCode.ERROR_EXTRACTING_TARGET}}
                 )
 
@@ -280,13 +281,15 @@ def build_graph(
                     op.source_id,
                 )
                 source_title, source_content = "", ""
-                op = op.model_copy(
-                    update={"error_codes": op.error_codes | {ErrorCode.ERROR_EXTRACTING_SOURCE}}
+                updated_op = updated_op.model_copy(
+                    update={
+                        "error_codes": updated_op.error_codes | {ErrorCode.ERROR_EXTRACTING_SOURCE}
+                    }
                 )
             add_node(G, op.source_id, node_content=source_content, node_title=source_title)
             add_node(G, op.target_id, node_content=target_content, node_title=target_title)
-            add_edge(G, op)
-            updated_ops.append(op)
+            add_edge(G, updated_op)
+            updated_ops.append(updated_op)
         except Exception as e:
             error_msg = f"Operation {op.id} skipped: {str(e)}"
             _LOGGER.warning(error_msg)

--- a/ocapi/step_resolution/build_op_graph.py
+++ b/ocapi/step_resolution/build_op_graph.py
@@ -171,15 +171,24 @@ def build_graph(
 ) -> Tuple[nx.MultiDiGraph, list[ArreteFile], list[tuple[Operation, str]], list[Operation]]:
     """Build the operations graph.
 
-    Returns the graph, the list of arrêtés, the list of failed operations,
-    and the operations list with their ``error_codes`` updated for the ones
-    resolved at graph-building time (full removals marked ``RESOLVED``,
-    missing target sections marked ``ERROR_EXTRACTING_TARGET``).
+    Returns the graph, the list of arrêtés, the list of skipped operations
+    (as ``(operation, reason)`` pairs), and the full operations list with
+    their ``error_codes`` updated for the cases handled at graph-building
+    time:
 
-    A full removal (REMOVE/REPLACE ALL) targeting an arrêté flagged as
-    ``principal`` is not applied: the operation is marked
-    ``ERROR_EXTRACTING_TARGET`` because such a removal most likely reflects
-    a detection mistake.
+    * Full removals (REMOVE/REPLACE ALL) that are successfully applied keep
+      ``error_codes`` empty.
+    * Full removals whose target arrêté is absent from the permit are marked
+      ``MISSING_ARRETE``.
+    * Full removals whose target arrêté is ``principal`` are marked
+      ``ERROR_EXTRACTING_TARGET`` (likely a detection mistake).
+    * Full removals that overlap with narrower operations from the same
+      source are marked ``LESS_IMPORTANT``.
+    * Non-full-removal operations whose target arrêté is missing are marked
+      ``MISSING_ARRETE`` and added to ``skipped_ops``.
+    * Operations whose target section is not found receive
+      ``ERROR_EXTRACTING_TARGET``; missing source sections receive
+      ``ERROR_EXTRACTING_SOURCE``.
     """
     G = nx.MultiDiGraph()
     soups: dict[ArreteId, BeautifulSoup] = {
@@ -284,7 +293,7 @@ def build_graph(
         except Exception as e:
             error_msg = f"Operation {op.id} skipped: {str(e)}"
             _LOGGER.warning(error_msg)
-            skipped_ops.append((op, str(e)))
+            skipped_ops.append((op, error_msg))
             updated_ops.append(op)
             continue
 

--- a/ocapi/step_resolution/build_op_graph.py
+++ b/ocapi/step_resolution/build_op_graph.py
@@ -178,12 +178,10 @@ def build_graph(
 
     * Full removals (REMOVE/REPLACE ALL) that are successfully applied keep
       ``error_codes`` empty.
-    * Full removals whose target arrêté is absent from the permit are marked
-      ``MISSING_ARRETE``.
-    * Full removals whose target arrêté is ``principal`` are marked
-      ``ERROR_EXTRACTING_TARGET`` (likely a detection mistake).
-    * Full removals that overlap with narrower operations from the same
-      source are marked ``LESS_IMPORTANT``.
+    * Full removals whose target arrêté is ``principal``, overlaps with
+      narrower operations, or is absent from the permit are **not** applied;
+      they are marked ``ERROR_EXTRACTING_TARGET``, ``LESS_IMPORTANT``, or
+      ``MISSING_ARRETE`` respectively, and added to ``skipped_ops``.
     * Non-full-removal operations whose target arrêté is missing are marked
       ``MISSING_ARRETE`` and added to ``skipped_ops``.
     * Operations whose target section is not found receive
@@ -202,43 +200,42 @@ def build_graph(
         try:
             if _is_full_removal_op(op):
                 if op.target_id.arrete_id in principal_ids:
-                    _LOGGER.warning(
-                        "A full removal of the principal arrete has been detected. "
-                        "This operation was not resolved."
+                    reason = (
+                        f"Operation {op.id}: full removal of principal arrete "
+                        f"{op.target_id.arrete_id} was not applied"
                     )
-                    updated_ops.append(
-                        op.model_copy(
-                            update={
-                                "error_codes": op.error_codes | {ErrorCode.ERROR_EXTRACTING_TARGET}
-                            }
-                        )
+                    _LOGGER.warning(reason)
+                    updated_op = op.model_copy(
+                        update={"error_codes": op.error_codes | {ErrorCode.ERROR_EXTRACTING_TARGET}}
                     )
+                    skipped_ops.append((updated_op, reason))
+                    updated_ops.append(updated_op)
                     continue
                 if _has_more_specific_ops(op, ops):
-                    _LOGGER.warning(
-                        "Full removal of arrete %s by %s overlaps with narrower operations "
-                        "from the same source; dropping the abrogation as LESS_IMPORTANT.",
-                        op.target_id.arrete_id,
-                        op.source_id.arrete_id,
+                    reason = (
+                        f"Operation {op.id}: full removal of arrete "
+                        f"{op.target_id.arrete_id} by {op.source_id.arrete_id} overlaps "
+                        f"with narrower operations from the same source (LESS_IMPORTANT)"
                     )
-                    updated_ops.append(
-                        op.model_copy(
-                            update={"error_codes": op.error_codes | {ErrorCode.LESS_IMPORTANT}}
-                        )
+                    _LOGGER.warning(reason)
+                    updated_op = op.model_copy(
+                        update={"error_codes": op.error_codes | {ErrorCode.LESS_IMPORTANT}}
                     )
+                    skipped_ops.append((updated_op, reason))
+                    updated_ops.append(updated_op)
                     continue
                 if op.target_id.arrete_id not in soups:
-                    _LOGGER.warning(
-                        "Full removal of arrete %s by %s targets an arrete missing "
-                        "from the permit; marking MISSING_ARRETE.",
-                        op.target_id.arrete_id,
-                        op.source_id.arrete_id,
+                    reason = (
+                        f"Operation {op.id}: full removal targets arrete "
+                        f"{op.target_id.arrete_id} which is missing from the permit "
+                        f"(MISSING_ARRETE)"
                     )
-                    updated_ops.append(
-                        op.model_copy(
-                            update={"error_codes": op.error_codes | {ErrorCode.MISSING_ARRETE}}
-                        )
+                    _LOGGER.warning(reason)
+                    updated_op = op.model_copy(
+                        update={"error_codes": op.error_codes | {ErrorCode.MISSING_ARRETE}}
                     )
+                    skipped_ops.append((updated_op, reason))
+                    updated_ops.append(updated_op)
                     continue
                 for arrete_file in arrete_files:
                     if arrete_file.id == op.target_id.arrete_id:

--- a/ocapi/step_resolution/build_op_graph.py
+++ b/ocapi/step_resolution/build_op_graph.py
@@ -242,6 +242,9 @@ def build_graph(
             if target_soup is None:
                 error_msg = f"Operation {op.id}: arrêté {op.target_id.arrete_id} not found in files"
                 _LOGGER.warning(error_msg)
+                op = op.model_copy(
+                    update={"error_codes": op.error_codes | {ErrorCode.MISSING_ARRETE}}
+                )
                 skipped_ops.append((op, error_msg))
                 updated_ops.append(op)
                 continue

--- a/ocapi/step_resolution/build_op_graph_test.py
+++ b/ocapi/step_resolution/build_op_graph_test.py
@@ -318,12 +318,15 @@ def test_build_graph_full_removal_on_principal_is_not_resolved() -> None:
         )
     ]
 
-    G, updated_arrete_files, _, updated_ops = build_graph(ops, [principal, later])
+    G, updated_arrete_files, skipped_ops, updated_ops = build_graph(ops, [principal, later])
 
     assert len(G.nodes) == 0
     assert len(G.edges) == 0
     assert next(af for af in updated_arrete_files if af.id == "2020-04-20").status is True
     assert ErrorCode.ERROR_EXTRACTING_TARGET in updated_ops[0].error_codes
+    assert len(skipped_ops) == 1
+    assert skipped_ops[0][0].id == "1"
+    assert "principal" in skipped_ops[0][1]
 
 
 def test_build_graph_full_removal_with_narrower_ops_marks_less_important() -> None:
@@ -368,11 +371,16 @@ def test_build_graph_full_removal_with_narrower_ops_marks_less_important() -> No
         sub_target=SubTarget(type=SubTargetType.FULL_SECTION),
     )
 
-    G, updated_arrete_files, _, updated_ops = build_graph([full_removal, narrower], arrete_files)
+    G, updated_arrete_files, skipped_ops, updated_ops = build_graph(
+        [full_removal, narrower], arrete_files
+    )
 
     assert next(af for af in updated_arrete_files if af.id == "2010-01-01").status is True
     full_removal_updated = next(o for o in updated_ops if o.id == "op-remove-all")
     assert ErrorCode.LESS_IMPORTANT in full_removal_updated.error_codes
+    assert len(skipped_ops) == 1
+    assert skipped_ops[0][0].id == "op-remove-all"
+    assert "LESS_IMPORTANT" in skipped_ops[0][1]
     # The full removal must not be added to the graph.
     assert not G.has_edge(
         NodeId(arrete_id="2025-01-01", article_id="30"),
@@ -439,11 +447,13 @@ def test_build_graph_full_removal_on_missing_arrete() -> None:
         operation_type=OperationType.REMOVE,
     )
 
-    G, _, _, updated_ops = build_graph([full_removal], arrete_files)
+    G, _, skipped_ops, updated_ops = build_graph([full_removal], arrete_files)
 
     op_updated = next(o for o in updated_ops if o.id == "op-missing")
     assert ErrorCode.MISSING_ARRETE in op_updated.error_codes
-    # No edge added since the target isn't part of the graph.
+    assert len(skipped_ops) == 1
+    assert skipped_ops[0][0].id == "op-missing"
+    assert "MISSING_ARRETE" in skipped_ops[0][1]
     assert not G.has_edge(
         NodeId(arrete_id="2025-01-01", article_id="1"),
         NodeId(arrete_id="1995-06-15", article_id="ALL"),
@@ -451,7 +461,7 @@ def test_build_graph_full_removal_on_missing_arrete() -> None:
 
 
 def test_build_graph_non_full_removal_on_missing_arrete() -> None:
-    """Any operation targeting a missing arrete is flagged MISSING_ARRETE."""
+    """Any operation targeting a missing arrêté is flagged MISSING_ARRETE."""
     html_2025 = """
     <section data-spec="section" data-number="1">Source 1</section>
     """

--- a/ocapi/step_resolution/build_op_graph_test.py
+++ b/ocapi/step_resolution/build_op_graph_test.py
@@ -450,6 +450,40 @@ def test_build_graph_full_removal_on_missing_arrete() -> None:
     )
 
 
+def test_build_graph_non_full_removal_on_missing_arrete() -> None:
+    """Any operation targeting a missing arrete is flagged MISSING_ARRETE."""
+    html_2025 = """
+    <section data-spec="section" data-number="1">Source 1</section>
+    """
+    arrete_files = [
+        ArreteFile(
+            id="2025-01-01",
+            aiot="aiot1",
+            filename="2025-01-01.html",
+            soup=BeautifulSoup(html_2025, "html.parser"),
+            file_type=FileType.AUTRE,
+        ),
+    ]
+    replace_op = Operation(
+        id="op-replace-missing",
+        source_id=NodeId(arrete_id="2025-01-01", article_id="1"),
+        target_id=NodeId(arrete_id="1995-06-15", article_id="2"),
+        operation_type=OperationType.REPLACE,
+        operand="<p>new content</p>",
+        sub_target=SubTarget(type=SubTargetType.FULL_SECTION),
+    )
+
+    G, _, skipped_ops, updated_ops = build_graph([replace_op], arrete_files)
+
+    op_updated = next(o for o in updated_ops if o.id == "op-replace-missing")
+    assert ErrorCode.MISSING_ARRETE in op_updated.error_codes
+    assert len(skipped_ops) == 1
+    assert not G.has_edge(
+        NodeId(arrete_id="2025-01-01", article_id="1"),
+        NodeId(arrete_id="1995-06-15", article_id="2"),
+    )
+
+
 def test_build_graph_full_removal_with_narrower_ops_from_other_source_still_abrogates() -> None:
     """The narrower ops must come from the same source arrêté to invalidate the abrogation."""
     html_2010 = """

--- a/snapshots/arretes_consolidation/0003013459/operations.json
+++ b/snapshots/arretes_consolidation/0003013459/operations.json
@@ -19,7 +19,9 @@
   },
   {
     "confidence_score": 95,
-    "error_codes": [],
+    "error_codes": [
+      "missing_arrete"
+    ],
     "id": "2",
     "operation_type": "REPLACE",
     "source_id": {

--- a/snapshots/arretes_consolidation/0003013459/permis.html
+++ b/snapshots/arretes_consolidation/0003013459/permis.html
@@ -4411,7 +4411,7 @@
 <section data-date_version="2021-09-24" data-is_modified="false" data-number="5.1.4" data-spec="section_version" data-title="Suivi des déchets" data-type="article">
 <h4 data-level="2" data-spec="section_title">
        Article 5.1.4. Suivi des déchets
-      </h4><div data-spec="operation_result" style="color: #1b4d89; font-style: italic; margin: 0.5rem 0;">Opération de consolidation résolue (modification) dans l'article 2 de l'arrêté 2012-02-29</div>
+      </h4><div data-spec="operation_result" style="color: #1b4d89; font-style: italic; margin: 0.5rem 0;">Opération de consolidation non résolue (modification) dans l'article 2 de l'arrêté 2012-02-29 (raison : L'arrêté cible n'est pas présent dans le permis consolidé)</div>
 <div data-number="1" data-spec="alinea">
        L'exploitant tient à jour le registre des déchets prévu à l'
        <a data-parent_reference="37" data-spec="section_reference" data-start_num="2" data-type="article">


### PR DESCRIPTION
All operations targeting an arrêté that is absent from the permit are now flagged with the MISSING_ARRETE error code. This change broadens the application of the error code beyond full removals to include any operation that references a missing arrêté. Updates to documentation and tests ensure clarity and coverage of this behavior. Fixes #135