### PR TITLE
Fix token reporting and save detected operations to JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      # Install mistralai from its GitHub tag because the project is currently
-      # quarantined on PyPI (security incident on the 2.4.6 release on 2026-05-12).
-      # Drop this once PyPI un-quarantines mistralai.
-      - run: pip install "mistralai @ git+https://github.com/mistralai/client-python.git@v1.12.4"
       - run: pip install .[dev]
 
       - name: Run unit tests
@@ -49,8 +45,6 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      # See note in unit-tests job; remove once mistralai is back on PyPI.
-      - run: pip install "mistralai @ git+https://github.com/mistralai/client-python.git@v1.12.4"
       - run: pip install .[dev]
 
       - run: mypy

--- a/config/llm_models.json
+++ b/config/llm_models.json
@@ -16,6 +16,21 @@
       "model_id": "gpt-5-mini",
       "reasoning_model": true
     },
+    "openai_gpt54": {
+      "provider": "openai",
+      "model_id": "gpt-5.4",
+      "reasoning_model": true
+    },
+    "openai_gpt54mini": {
+      "provider": "openai",
+      "model_id": "gpt-5.4-mini",
+      "reasoning_model": true
+    },
+    "openai_gpt54nano": {
+      "provider": "openai",
+      "model_id": "gpt-5.4-nano",
+      "reasoning_model": true
+    },
     "openai_gpt5nano": {
       "provider": "openai",
       "model_id": "gpt-5-nano",
@@ -27,27 +42,43 @@
     },
     "mistral_medium_3_5": {
       "provider": "mistral",
-      "model_id": "mistral-medium-3.5"
+      "model_id": "mistral-medium-3-5"
     },
     "piag_mistral_medium": {
       "provider": "mte-piag",
       "model_id": "mte-api-piag-mistral-medium-latest"
     },
-    "anthropic_sonnet": {
+    "mistral_large": {
+      "provider": "mistral",
+      "model_id": "mistral-large-2512"
+    },
+    "anthropic_sonnet4": {
       "provider": "anthropic",
       "model_id": "claude-sonnet-4-20250514"
     },
-    "anthropic_haiku": {
+    "anthropic_haiku4": {
       "provider": "anthropic",
       "model_id": "claude-haiku-4-20250414"
     },
-    "anthropic_opus": {
+    "anthropic_opus46": {
       "provider": "anthropic",
       "model_id": "claude-opus-4-6"
     },
-    "gemini_pro": {
+    "gemini_pro25": {
       "provider": "google",
       "model_id": "gemini-2.5-pro"
+    },
+    "gemini_flash": {
+      "provider": "google",
+      "model_id": "gemini-3-flash-preview"
+    },
+    "gemini_flash_lite": {
+      "provider": "google",
+      "model_id": "gemini-3.1-flash-lite-preview"
+    },
+    "gemini_pro31": {
+      "provider": "google",
+      "model_id": "gemini-3.1-pro-preview"
     }
   }
 }

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -23,6 +23,7 @@ flowchart LR
   models[config/llm_models.json] --> det[step_detection]
   html[snapshots/arretes_html/AIOT] --> det
   det --> dops[Detected ops]
+  det --> opsfile["&lt;ops-dir&gt;/AIOT/operations.json\n(optionnel)"]
   gt[snapshots/ground-truth/AIOT/operations.json] --> cmp[compare_operations]
   dops --> cmp
   cmp --> tp[(TP/FP/FN)]
@@ -50,10 +51,58 @@ python scripts/evaluate_detection.py --model mistral_medium -v
 # Export XLSX
 python scripts/evaluate_detection.py --model openai_gpt5 --xlsx
 python scripts/evaluate_detection.py --model openai_gpt5 --xlsx ./mon_eval.xlsx
+
+# Détection + sauvegarde des opérations détectées
+python scripts/evaluate_detection.py --model openai_gpt5mini \
+    --ops-dir eval_gpt5mini_20260601/
+
+# Recalculer les métriques sans LLM à partir d'ops existantes
+python scripts/evaluate_detection.py --model openai_gpt5mini \
+    --score --ops-dir eval_gpt5mini_20260601/
 ```
 
 `--model` accepte n'importe quelle `model_key` déclarée dans
 [`config/llm_models.json`](https://github.com/mte-dgpr/ocapi/blob/main/config/llm_models.json).
+
+## Sauvegarde des opérations détectées (`--ops-dir`)
+
+En passant `--ops-dir DIR`, le script sauvegarde après chaque AIOT les
+opérations détectées dans `DIR/<aiot>/operations.json`.
+
+Le format est identique au ground-truth (`snapshots/ground-truth/<aiot>/operations.json`) :
+
+```json
+[
+  {
+    "id": "...",
+    "operation_type": "REPLACE",
+    "source_id": { "arrete_id": "...", "article_id": "..." },
+    "target_id": { "arrete_id": "...", "article_id": "..." }
+  }
+]
+```
+
+Les clés JSON sont triées alphabétiquement (`sort_keys=True`) pour produire
+des diffs stables sous git.
+
+> **Convention de nommage** : inclure le modèle et la date dans le nom du
+> dossier, par exemple `eval_gpt5mini_20260601_120000/`. Le script ne stocke
+> pas ces métadonnées dans le fichier lui-même.
+
+## Mode score (`--score`)
+
+Relit un dossier d'`operations.json` existants et recalcule les métriques
+**sans aucun appel LLM**.
+
+```bash
+python scripts/evaluate_detection.py --model openai_gpt5mini \
+    --score --ops-dir eval_gpt5mini_20260601/
+```
+
+- `--model` reste obligatoire (utilisé pour nommer le fichier XLSX éventuel).
+- `--aiot` est optionnel : par défaut, tous les sous-dossiers contenant un
+  `operations.json` sont traités.
+- Compatible avec `--xlsx`.
 
 ## Critère de matching
 

--- a/ocapi/cli.py
+++ b/ocapi/cli.py
@@ -46,6 +46,7 @@ from ocapi.utils.io_utils import (
     write_permis_output,
 )
 from ocapi.utils.logging_utils import get_logger, initialize_root_logger
+from ocapi.utils.utils import strip_none_values
 
 _LOGGER = get_logger(__name__)
 
@@ -242,9 +243,10 @@ def cmd_update_snapshots(args: argparse.Namespace) -> int:
             operations=operations,
         )
         consolidation_dir.mkdir(parents=True, exist_ok=True)
-        ops_dict = [op.model_dump(mode="json") for op in ops]
-        write_json_output(ops_dict, consolidation_dir / "operations.json")
-        write_json_output(article_history_to_json_dict(history), consolidation_dir / "history.json")
+        ops_dict = strip_none_values([op.model_dump(mode="json") for op in ops])
+        history_dict = strip_none_values(article_history_to_json_dict(history))
+        write_json_output(ops_dict, consolidation_dir / "operations.json", sort_keys=True)
+        write_json_output(history_dict, consolidation_dir / "history.json", sort_keys=True)
         if permis:
             write_permis_output(permis_to_html(permis), consolidation_dir / "permis.html")
         _LOGGER.info(f"Updated snapshots → {consolidation_dir}")

--- a/ocapi/llm_utils/config.py
+++ b/ocapi/llm_utils/config.py
@@ -189,6 +189,10 @@ def _resolve_model_key(model: str | None, models_cfg: dict[str, Any]) -> str:
         "mte-api-piag-mistral-medium-latest": "piag_mistral_medium",
         "mistral-medium-latest": "mistral_medium",
         "mistral-large-latest": "mistral_large",
+        "anthropic_sonnet": "anthropic_sonnet4",
+        "anthropic_haiku": "anthropic_haiku4",
+        "anthropic_opus": "anthropic_opus46",
+        "gemini_pro": "gemini_pro25",
     }
     if model in legacy_aliases and legacy_aliases[model] in models:
         return legacy_aliases[model]

--- a/ocapi/llm_utils/core.py
+++ b/ocapi/llm_utils/core.py
@@ -132,13 +132,15 @@ def _build_payload(model: ResolvedLLMModel, prompt: str) -> dict[str, Any]:
         }
 
     if model.provider == "google":
-        return {
+        payload = {
             "model": model.model_name,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": 0,
             "n": 1,
         }
-
+        if model.temperature is not None:
+            payload["temperature"] = model.temperature
+        return payload
     raise LLMConfigError(f"Unsupported LLM provider: {model.provider}")
 
 

--- a/ocapi/llm_utils/core.py
+++ b/ocapi/llm_utils/core.py
@@ -56,12 +56,41 @@ _accumulated_usage = TokenUsage()
 
 
 def reset_accumulated_usage() -> None:
-    global _accumulated_usage
-    _accumulated_usage = TokenUsage()
+    _accumulated_usage.prompt_tokens = 0
+    _accumulated_usage.completion_tokens = 0
 
 
 def get_accumulated_usage() -> TokenUsage:
     return _accumulated_usage
+
+
+def _extract_content(model_provider: str, data: Any) -> str:
+    """Extract the text content from a raw LLM API response dict.
+
+    Raises LLMResponseError if the expected fields are missing.
+    """
+    try:
+        if model_provider == "anthropic":
+            return str(data["content"][0]["text"])
+        return str(data["choices"][0]["message"]["content"])
+    except (TypeError, KeyError, IndexError) as exc:
+        raise LLMResponseError("Invalid LLM response format") from exc
+
+
+def _accumulate_usage(model_provider: str, data: Any) -> None:
+    """Add token counts from a successful API response to the global accumulator."""
+    try:
+        usage = data.get("usage") or {}
+        if model_provider == "anthropic":
+            prompt = int(usage.get("input_tokens") or 0)
+            completion = int(usage.get("output_tokens") or 0)
+        else:
+            prompt = int(usage.get("prompt_tokens") or 0)
+            completion = int(usage.get("completion_tokens") or 0)
+        _accumulated_usage.prompt_tokens += prompt
+        _accumulated_usage.completion_tokens += completion
+    except (TypeError, ValueError, AttributeError):
+        _LOGGER.debug("Could not extract token usage from LLM response.")
 
 
 def _build_payload(model: ResolvedLLMModel, prompt: str) -> dict[str, Any]:
@@ -210,15 +239,15 @@ def _execute_model_call(
             response.raise_for_status()
             data: Any = response.json()
             try:
-                if model.provider == "anthropic":
-                    return str(data["content"][0]["text"])
-                return str(data["choices"][0]["message"]["content"])
-            except (TypeError, KeyError, IndexError) as exc:
+                content = _extract_content(model.provider, data)
+            except LLMResponseError:
                 _LOGGER.error(
                     f"Invalid LLM API response ({model.model_name}): "
                     f"unexpected response format. Raw response: {data}"
                 )
-                raise LLMResponseError("Invalid LLM response format") from exc
+                raise
+            _accumulate_usage(model.provider, data)
+            return content
         except requests.exceptions.RequestException as exc:
             retryable = _is_retryable_http_error(exc)
             is_last_attempt = attempt >= max_attempts

--- a/ocapi/llm_utils/core_test.py
+++ b/ocapi/llm_utils/core_test.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -24,12 +25,31 @@ import requests
 import ocapi.llm_utils.core as llm_utils_module
 from ocapi.exceptions import LLMNetworkError, LLMResponseError
 from ocapi.llm_utils import ResolvedLLMModel, call_llm_api
+from ocapi.llm_utils.config import _DEFAULT_LLM_MODELS_CONFIG, _DEFAULT_LLM_RESILIENCE_CONFIG
+from ocapi.llm_utils.core import get_accumulated_usage, reset_accumulated_usage
 
 
-def _make_success_response(content: str) -> Mock:
+def _make_success_response(
+    content: str, prompt_tokens: int = 0, completion_tokens: int = 0
+) -> Mock:
     response = Mock()
     response.raise_for_status.return_value = None
-    response.json.return_value = {"choices": [{"message": {"content": content}}]}
+    response.json.return_value = {
+        "choices": [{"message": {"content": content}}],
+        "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
+    }
+    return response
+
+
+def _make_anthropic_success_response(
+    content: str, input_tokens: int = 0, output_tokens: int = 0
+) -> Mock:
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "content": [{"text": content}],
+        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+    }
     return response
 
 
@@ -294,3 +314,135 @@ def test_call_llm_api_rate_limit_disabled_does_not_sleep() -> None:
     assert mocked_post.call_count == 1
     assert mocked_sleep.call_count == 0
     llm_utils_module._RATE_LIMIT_LAST_CALL_MONOTONIC = None
+
+
+# ---------------------------------------------------------------------------
+# Token usage accumulation
+# ---------------------------------------------------------------------------
+
+
+def _make_base_cfg() -> ResolvedLLMModel:
+    """Return a ResolvedLLMModel built from the default primary model config."""
+    primary_key = str(_DEFAULT_LLM_MODELS_CONFIG["primary_model_key"])
+    spec = _DEFAULT_LLM_MODELS_CONFIG["models"][primary_key]
+    return ResolvedLLMModel(
+        model_key=primary_key,
+        provider=spec["provider"],
+        model_name=spec["model_id"],
+        api_key="test-key",
+        api_url="https://piag.example",
+    )
+
+
+def _make_base_resilience() -> dict[str, Any]:
+    """Return the default resilience config with retries capped to 1 for fast tests."""
+    return {
+        **_DEFAULT_LLM_RESILIENCE_CONFIG,
+        "retry": {"primary": {"max_attempts": 1}},
+    }
+
+
+def test_token_usage_accumulated_after_successful_call() -> None:
+    """prompt_tokens and completion_tokens are recorded after a successful call."""
+    reset_accumulated_usage()
+
+    with patch(
+        "ocapi.llm_utils.core._load_llm_resilience_config", return_value=_make_base_resilience()
+    ):
+        with patch(
+            "ocapi.llm_utils.core.requests.post",
+            return_value=_make_success_response("ok", prompt_tokens=100, completion_tokens=50),
+        ):
+            call_llm_api(_make_base_cfg(), "prompt")
+
+    usage = get_accumulated_usage()
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 50
+
+
+def test_token_usage_accumulated_over_multiple_calls() -> None:
+    """The accumulator sums tokens across successive calls."""
+    reset_accumulated_usage()
+    cfg = _make_base_cfg()
+
+    with patch(
+        "ocapi.llm_utils.core._load_llm_resilience_config", return_value=_make_base_resilience()
+    ):
+        with patch(
+            "ocapi.llm_utils.core.requests.post",
+            side_effect=[
+                _make_success_response("r1", prompt_tokens=200, completion_tokens=40),
+                _make_success_response("r2", prompt_tokens=300, completion_tokens=60),
+            ],
+        ):
+            call_llm_api(cfg, "prompt-1")
+            call_llm_api(cfg, "prompt-2")
+
+    usage = get_accumulated_usage()
+    assert usage.prompt_tokens == 500
+    assert usage.completion_tokens == 100
+
+
+def test_reset_accumulated_usage_clears_counts() -> None:
+    """reset_accumulated_usage zeroes the counters in-place (same object reference)."""
+    reset_accumulated_usage()
+
+    with patch(
+        "ocapi.llm_utils.core._load_llm_resilience_config", return_value=_make_base_resilience()
+    ):
+        with patch(
+            "ocapi.llm_utils.core.requests.post",
+            return_value=_make_success_response("ok", prompt_tokens=100, completion_tokens=50),
+        ):
+            call_llm_api(_make_base_cfg(), "prompt")
+
+    # The object returned before reset must reflect the reset because it is the same instance.
+    usage_ref = get_accumulated_usage()
+    reset_accumulated_usage()
+    assert usage_ref.prompt_tokens == 0
+    assert usage_ref.completion_tokens == 0
+
+
+def test_token_usage_anthropic_provider() -> None:
+    """For Anthropic, input_tokens/output_tokens fields are correctly mapped."""
+    reset_accumulated_usage()
+    anthropic_cfg = ResolvedLLMModel(
+        model_key="anthropic_claude",
+        provider="anthropic",
+        model_name="claude-sonnet-4-20250514",
+        api_key="ant-key",
+        api_url="https://api.anthropic.com/v1/messages",
+    )
+
+    with patch(
+        "ocapi.llm_utils.core._load_llm_resilience_config", return_value=_make_base_resilience()
+    ):
+        with patch(
+            "ocapi.llm_utils.core.requests.post",
+            return_value=_make_anthropic_success_response("ok", input_tokens=80, output_tokens=20),
+        ):
+            call_llm_api(anthropic_cfg, "prompt")
+
+    usage = get_accumulated_usage()
+    assert usage.prompt_tokens == 80
+    assert usage.completion_tokens == 20
+
+
+def test_token_usage_missing_usage_field_does_not_raise() -> None:
+    """If 'usage' is absent from the response, the call succeeds and counters remain at zero."""
+    reset_accumulated_usage()
+
+    response_without_usage = Mock()
+    response_without_usage.raise_for_status.return_value = None
+    response_without_usage.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    with patch(
+        "ocapi.llm_utils.core._load_llm_resilience_config", return_value=_make_base_resilience()
+    ):
+        with patch("ocapi.llm_utils.core.requests.post", return_value=response_without_usage):
+            result = call_llm_api(_make_base_cfg(), "prompt")
+
+    assert result == "ok"
+    usage = get_accumulated_usage()
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0

--- a/ocapi/snapshot_test.py
+++ b/ocapi/snapshot_test.py
@@ -28,7 +28,12 @@ import pytest
 from ocapi.pipeline import run_pipeline
 from ocapi.snapshot import SNAPSHOT_CASES
 from ocapi.step_rendering.step_rendering import permis_to_html
-from ocapi.utils.io_utils import article_history_to_json_dict, load_arrete_files, load_operations
+from ocapi.utils.io_utils import (
+    article_history_to_json_dict,
+    load_arrete_files,
+    load_operations,
+    write_json_output,
+)
 from ocapi.utils.testing import normalize_html
 from ocapi.utils.utils import strip_none_values
 
@@ -79,11 +84,7 @@ def test_snapshot_pipeline_output(
     if UPDATE_SNAPSHOTS:
         snapshot_dir.mkdir(parents=True, exist_ok=True)
         for filename, data in [("operations.json", ops_json), ("history.json", history_json)]:
-            (snapshot_dir / filename).write_text(
-                json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-                newline="\n",
-            )
+            write_json_output(data, snapshot_dir / filename, sort_keys=True)
         if permis_html:
             (snapshot_dir / "permis.html").write_text(
                 normalize_html(permis_html), encoding="utf-8", newline="\n"

--- a/ocapi/utils/io_utils.py
+++ b/ocapi/utils/io_utils.py
@@ -397,7 +397,7 @@ def save_tagged_html_file(document_context: DocumentContext, output_path: Path) 
     # ``arretify.step_segmentation`` (and its spaCy model) at import time.
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(document_context.soup.prettify(), encoding="utf-8")
+        output_path.write_text(document_context.soup.prettify(), encoding="utf-8", newline="\n")
     except OSError as e:
         raise InputOutputError(f"Cannot write tagged HTML file: {e}") from e
 
@@ -406,7 +406,7 @@ def write_permis_output(permis_html: str, output_path: Path) -> None:
     """Write the rendered consolidated permit HTML to *output_path*."""
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(permis_html, encoding="utf-8")
+        output_path.write_text(permis_html, encoding="utf-8", newline="\n")
     except OSError as e:
         raise InputOutputError(f"Cannot write to output file: {e}") from e
 
@@ -433,7 +433,7 @@ def write_json_output(data: Any, output_path: Path, *, sort_keys: bool = False) 
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Save as JSON (trailing newline follows POSIX text-file convention)
-        with output_path.open("w", encoding="utf-8") as f:
+        with output_path.open("w", encoding="utf-8", newline="\n") as f:
             json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=sort_keys)
             f.write("\n")
 
@@ -554,7 +554,7 @@ def save_history(history: ArticleHistory, output_dir: Path) -> None:
     output_path = output_dir / "history.json"
     try:
         serialized = article_history_to_json_dict(history)
-        with output_path.open("w", encoding="utf-8") as f:
+        with output_path.open("w", encoding="utf-8", newline="\n") as f:
             json.dump(serialized, f, ensure_ascii=False, indent=2)
     except OSError as e:
         raise InputOutputError(f"Cannot write history file: {e}") from e

--- a/ocapi/utils/io_utils.py
+++ b/ocapi/utils/io_utils.py
@@ -411,7 +411,7 @@ def write_permis_output(permis_html: str, output_path: Path) -> None:
         raise InputOutputError(f"Cannot write to output file: {e}") from e
 
 
-def write_json_output(data: Any, output_path: Path) -> None:
+def write_json_output(data: Any, output_path: Path, *, sort_keys: bool = False) -> None:
     """Write data to a JSON file.
 
     Parameters
@@ -420,6 +420,8 @@ def write_json_output(data: Any, output_path: Path) -> None:
         Data to save (dict, list, or any JSON-serialisable object).
     output_path : Path
         Output file path.
+    sort_keys : bool
+        If ``True``, sort object keys alphabetically (default: ``False``).
 
     Raises
     ------
@@ -430,9 +432,10 @@ def write_json_output(data: Any, output_path: Path) -> None:
         # Create parent directory if needed
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Save as JSON
+        # Save as JSON (trailing newline follows POSIX text-file convention)
         with output_path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+            json.dump(data, f, ensure_ascii=False, indent=2, sort_keys=sort_keys)
+            f.write("\n")
 
     except OSError as e:
         raise InputOutputError(f"Cannot write JSON file: {e}") from e

--- a/ocapi/utils/io_utils.py
+++ b/ocapi/utils/io_utils.py
@@ -453,19 +453,13 @@ def save_operations(operations: list[Operation], output_dir: Path) -> None:
     InputOutputError
         If writing fails.
     """
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / "operations.json"
-    try:
-        serialized = []
-        for op in operations:
-            data = op.model_dump(mode="json", exclude_defaults=True)
-            if not data.get("error_codes"):
-                data.pop("error_codes", None)
-            serialized.append(data)
-        with output_path.open("w", encoding="utf-8") as f:
-            json.dump(serialized, f, ensure_ascii=False, indent=2)
-    except OSError as e:
-        raise InputOutputError(f"Cannot write operations file: {e}") from e
+    serialized = []
+    for op in operations:
+        data = op.model_dump(mode="json", exclude_defaults=True)
+        if not data.get("error_codes"):
+            data.pop("error_codes", None)
+        serialized.append(data)
+    write_json_output(serialized, output_dir / "operations.json", sort_keys=True)
 
 
 def load_operations(input_dir: Path) -> list[Operation]:

--- a/ocapi/utils/io_utils_test.py
+++ b/ocapi/utils/io_utils_test.py
@@ -229,6 +229,24 @@ class TestSaveOperations:
         assert len(data) == 3
         assert [d["id"] for d in data] == ["op1", "op2", "op3"]
 
+    def test_keys_are_sorted_for_stable_diffs(self, tmp_path: Path) -> None:
+        """Keys of each serialized operation must be alphabetically sorted.
+
+        Without sort_keys, Pydantic emits keys in definition order
+        (id, source_id, target_id, operation_type, operand), which differs
+        from alphabetical order and produces noisy git diffs.
+        """
+        ops = [
+            make_testing_op(OperationType.REPLACE, operation_id="op1", operand="<p>a</p>"),
+            make_testing_op(OperationType.ADD, operation_id="op2", operand="<p>b</p>"),
+        ]
+        save_operations(ops, tmp_path)
+        data = json.loads((tmp_path / "operations.json").read_text(encoding="utf-8"))
+        assert len(data) == 2
+        for entry in data:
+            keys = list(entry.keys())
+            assert keys == sorted(keys), f"Keys not sorted in entry {entry.get('id')}: {keys}"
+
 
 class TestLoadOperations:
     def test_loads_previously_saved_operations(self, tmp_path: Path) -> None:

--- a/scripts/evaluate_detection.py
+++ b/scripts/evaluate_detection.py
@@ -296,6 +296,14 @@ def _run_score_mode(args: argparse.Namespace) -> int:
 
     # Determine which AIOTs to score: either from --aiot or all subdirs with ops.json
     if args.aiot:
+        missing = [aiot for aiot in args.aiot if not (ops_dir / aiot / "operations.json").exists()]
+        if missing:
+            for aiot in missing:
+                print(
+                    f"operations.json not found for AIOT {aiot!r} in {ops_dir}",
+                    file=sys.stderr,
+                )
+            return 1
         aiots = list(args.aiot)
     else:
         if not ops_dir.exists():
@@ -401,10 +409,6 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     initialize_root_logger(level="DEBUG" if args.verbose else "INFO", console_output=True)
-
-    if args.model is None:
-        print("--model is required.", file=sys.stderr)
-        return 1
 
     # --- score mode ---
     if args.score:

--- a/scripts/evaluate_detection.py
+++ b/scripts/evaluate_detection.py
@@ -61,9 +61,6 @@ _VALID_OP_TYPES = {"ADD", "REPLACE", "REMOVE"}
 
 # Cost per 1M tokens (USD): {model_id: (input_cost, output_cost)}
 _COST_PER_1M_TOKENS: dict[str, tuple[float, float]] = {
-    "mistral-medium-2508": (0.40, 2.00),
-    "mistral-medium-3.5": (1.50, 7.50),
-    "mistral-large-2512": (0.50, 1.50),
     "gpt-4o": (2.50, 10.00),
     "gpt-5": (1.25, 10.00),
     "gpt-5-mini": (0.25, 2.00),
@@ -71,6 +68,10 @@ _COST_PER_1M_TOKENS: dict[str, tuple[float, float]] = {
     "gpt-5.4": (2.50, 15.00),
     "gpt-5.4-mini": (0.75, 4.50),
     "gpt-5.4-nano": (0.20, 1.25),
+    "mte-api-piag-mistral-medium-latest": (2.00, 6.00),
+    "mistral-medium-2508": (0.40, 2.00),
+    "mistral-medium-3-5": (1.50, 7.50),
+    "mistral-large-2512": (0.50, 1.50),
     "claude-sonnet-4-20250514": (3.00, 15.00),
     "claude-haiku-4-20250414": (0.80, 4.00),
     "claude-opus-4-6": (5.00, 25.00),

--- a/scripts/evaluate_detection.py
+++ b/scripts/evaluate_detection.py
@@ -75,6 +75,8 @@ _COST_PER_1M_TOKENS: dict[str, tuple[float, float]] = {
     "claude-sonnet-4-20250514": (3.00, 15.00),
     "claude-haiku-4-20250414": (0.80, 4.00),
     "claude-opus-4-6": (5.00, 25.00),
+    "gemini-2.5-pro": (2.50, 10.00),
+    "gemini-3-flash-preview": (0.50, 3.00),
     "gemini-3.1-flash-lite-preview": (0.25, 1.50),
     "gemini-3.1-pro-preview": (4.00, 18.00),
 }

--- a/scripts/evaluate_detection.py
+++ b/scripts/evaluate_detection.py
@@ -309,6 +309,9 @@ def _run_score_mode(args: argparse.Namespace) -> int:
         if not ops_dir.exists():
             print(f"--ops-dir not found: {ops_dir}", file=sys.stderr)
             return 1
+        if not ops_dir.is_dir():
+            print(f"--ops-dir is not a directory: {ops_dir}", file=sys.stderr)
+            return 1
         aiots = sorted(
             d.name for d in ops_dir.iterdir() if d.is_dir() and (d / "operations.json").exists()
         )
@@ -380,8 +383,8 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         metavar="DIR",
         help=(
-            "In detection mode: directory where ops.json files are saved after each LLM run. "
-            "In score mode (--score): directory from which ops.json files are read."
+            "In detection mode: directory where operations.json files are saved after each LLM run."
+            " In score mode (--score): directory from which operations.json files are read."
         ),
     )
     parser.add_argument(

--- a/scripts/evaluate_detection.py
+++ b/scripts/evaluate_detection.py
@@ -49,7 +49,7 @@ from ocapi.llm_utils import (  # noqa: E402
 from ocapi.step_detection import step_detection as step_detection_module  # noqa: E402
 from ocapi.step_detection.step_detection import step_detection  # noqa: E402
 from ocapi.types import Operation  # noqa: E402
-from ocapi.utils.io_utils import load_arrete_files  # noqa: E402
+from ocapi.utils.io_utils import load_arrete_files, load_operations, save_operations  # noqa: E402
 from ocapi.utils.logging_utils import get_logger, initialize_root_logger  # noqa: E402
 
 _LOGGER = get_logger(__name__)
@@ -273,6 +273,83 @@ def _write_xlsx(
     wb.save(output_path)
 
 
+def _print_and_accumulate(
+    r: AiotResult,
+    total_tp: int,
+    total_fp: int,
+    total_fn: int,
+) -> tuple[int, int, int]:
+    print(f"\n--- {r.aiot} ---")
+    print(f"  Ground-truth: {r.gt_count}  |  Detected: {r.detected_count}")
+    print(f"  TP={r.tp}  FP={r.fp}  FN={r.fn}")
+    print(f"  Precision: {r.scores.precision:.3f}")
+    print(f"  Recall:    {r.scores.recall:.3f}")
+    print(f"  F1:        {r.scores.f1:.3f}")
+    return total_tp + r.tp, total_fp + r.fp, total_fn + r.fn
+
+
+def _run_score_mode(args: argparse.Namespace) -> int:
+    """Recompute metrics from existing ops.json files without any LLM call."""
+    ops_dir: Path = args.ops_dir
+
+    # Determine which AIOTs to score: either from --aiot or all subdirs with ops.json
+    if args.aiot:
+        aiots = list(args.aiot)
+    else:
+        if not ops_dir.exists():
+            print(f"--ops-dir not found: {ops_dir}", file=sys.stderr)
+            return 1
+        aiots = sorted(
+            d.name for d in ops_dir.iterdir() if d.is_dir() and (d / "operations.json").exists()
+        )
+
+    if not aiots:
+        print(f"No operations.json found in {ops_dir}", file=sys.stderr)
+        return 1
+
+    _LOGGER.info(f"Score mode — ops-dir: {ops_dir}")
+    _LOGGER.info(f"AIOTs: {', '.join(aiots)}")
+
+    total_tp, total_fp, total_fn = 0, 0, 0
+    results: list[AiotResult] = []
+
+    for aiot in aiots:
+        _LOGGER.info(f"\n{'=' * 50}")
+        _LOGGER.info(f"AIOT: {aiot}")
+        _LOGGER.info(f"{'=' * 50}")
+
+        gt_keys = load_ground_truth(aiot)
+        detected_ops = load_operations(ops_dir / aiot)
+        detected_keys = [_operation_key(op) for op in detected_ops]
+        _LOGGER.info(f"Ground-truth: {len(gt_keys)}  |  Loaded ops: {len(detected_keys)}")
+
+        tp, fp, fn = compare_operations(detected_keys, gt_keys)
+        scores = compute_scores(tp, fp, fn)
+
+        r = AiotResult(aiot, len(gt_keys), len(detected_keys), tp, fp, fn, scores)
+        results.append(r)
+        total_tp, total_fp, total_fn = _print_and_accumulate(r, total_tp, total_fp, total_fn)
+
+    overall = compute_scores(total_tp, total_fp, total_fn)
+    print(f"\n{'=' * 50}")
+    print(f"OVERALL (score mode — {args.model})")
+    print(f"{'=' * 50}")
+    print(f"  TP={total_tp}  FP={total_fp}  FN={total_fn}")
+    print(f"  Precision: {overall.precision:.3f}")
+    print(f"  Recall:    {overall.recall:.3f}")
+    print(f"  F1:        {overall.f1:.3f}")
+
+    if args.xlsx is not False:
+        xlsx_path = args.xlsx
+        if xlsx_path is None:
+            ts = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+            xlsx_path = _PROJECT_ROOT / f"eval_{args.model}_score_{ts}.xlsx"
+        _write_xlsx(results, overall, total_tp, total_fp, total_fn, args.model, xlsx_path)
+        print(f"\nResults exported to {xlsx_path}")
+
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Evaluate LLM operation detection against ground-truth.",
@@ -286,6 +363,24 @@ def main(argv: list[str] | None = None) -> int:
         "--aiot",
         nargs="*",
         help="AIOT(s) to evaluate (default: all available ground-truth AIOTs)",
+    )
+    parser.add_argument(
+        "--ops-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help=(
+            "In detection mode: directory where ops.json files are saved after each LLM run. "
+            "In score mode (--score): directory from which ops.json files are read."
+        ),
+    )
+    parser.add_argument(
+        "--score",
+        action="store_true",
+        help=(
+            "Score mode: recompute metrics from existing ops.json files (no LLM call). "
+            "Requires --ops-dir."
+        ),
     )
     parser.add_argument(
         "--xlsx",
@@ -304,6 +399,19 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     initialize_root_logger(level="DEBUG" if args.verbose else "INFO", console_output=True)
+
+    if args.model is None:
+        print("--model is required.", file=sys.stderr)
+        return 1
+
+    # --- score mode ---
+    if args.score:
+        if args.ops_dir is None:
+            print("--score requires --ops-dir.", file=sys.stderr)
+            return 1
+        return _run_score_mode(args)
+
+    # --- detection mode ---
 
     aiots = args.aiot or _available_aiots()
     if not aiots:
@@ -335,38 +443,33 @@ def main(argv: list[str] | None = None) -> int:
         usage = get_accumulated_usage()
         cost = _compute_cost(model_id, usage)
 
+        if args.ops_dir is not None:
+            out_dir = args.ops_dir / aiot
+            save_operations(detected_ops, out_dir)
+            _LOGGER.info(f"Ops saved to {out_dir / 'operations.json'}")
+
         detected_keys = [_operation_key(op) for op in detected_ops]
         _LOGGER.info(f"Detected: {len(detected_keys)} operations")
 
         tp, fp, fn = compare_operations(detected_keys, gt_keys)
         scores = compute_scores(tp, fp, fn)
 
-        results.append(
-            AiotResult(
-                aiot,
-                len(gt_keys),
-                len(detected_keys),
-                tp,
-                fp,
-                fn,
-                scores,
-                elapsed_seconds=elapsed,
-                usage=usage,
-                cost_usd=cost,
-            )
+        r = AiotResult(
+            aiot,
+            len(gt_keys),
+            len(detected_keys),
+            tp,
+            fp,
+            fn,
+            scores,
+            elapsed_seconds=elapsed,
+            usage=usage,
+            cost_usd=cost,
         )
+        results.append(r)
 
-        print(f"\n--- {aiot} ---")
-        print(f"  Ground-truth: {len(gt_keys)}  |  Detected: {len(detected_keys)}")
-        print(f"  TP={tp}  FP={fp}  FN={fn}")
-        print(f"  Precision: {scores.precision:.3f}")
-        print(f"  Recall:    {scores.recall:.3f}")
-        print(f"  F1:        {scores.f1:.3f}")
+        total_tp, total_fp, total_fn = _print_and_accumulate(r, total_tp, total_fp, total_fn)
         print(f"  Time: {elapsed:.1f}s  |  Tokens: {usage.total_tokens}  |  Cost: ${cost:.4f}")
-
-        total_tp += tp
-        total_fp += fp
-        total_fn += fn
 
     overall = compute_scores(total_tp, total_fp, total_fn)
     print(f"\n{'=' * 50}")

--- a/scripts/evaluate_detection_test.py
+++ b/scripts/evaluate_detection_test.py
@@ -161,6 +161,22 @@ class TestRunScoreMode:
     def _make_gt_file(self, path: Path) -> None:
         self._make_ops_file(path)
 
+    def test_ops_dir_is_a_file_returns_error(self, tmp_path: Path, capsys: pytest.CaptureFixture):
+        ops_dir = tmp_path / "ops.json"
+        ops_dir.write_text("not a directory")
+
+        args = mod.argparse.Namespace(
+            aiot=None,
+            ops_dir=ops_dir,
+            model="some_model",
+            xlsx=False,
+        )
+        result = mod._run_score_mode(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "not a directory" in captured.err
+
     def test_explicit_aiot_missing_operations_json_returns_error(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ):

--- a/scripts/evaluate_detection_test.py
+++ b/scripts/evaluate_detection_test.py
@@ -143,3 +143,63 @@ class TestLoadGroundTruth:
 
         assert len(keys) == 1
         assert keys[0] == ("2023-01-01", "1", "2022-01-01", "2", "REPLACE")
+
+
+class TestRunScoreMode:
+    def _make_ops_file(self, path: Path) -> None:
+        ops = [
+            {
+                "id": "op-1",
+                "source_id": {"arrete_id": "2023-01-01", "article_id": "1"},
+                "target_id": {"arrete_id": "2022-01-01", "article_id": "2"},
+                "operation_type": "REPLACE",
+            }
+        ]
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "operations.json").write_text(json.dumps(ops))
+
+    def _make_gt_file(self, path: Path) -> None:
+        self._make_ops_file(path)
+
+    def test_explicit_aiot_missing_operations_json_returns_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ):
+        ops_dir = tmp_path / "ops"
+        ops_dir.mkdir()
+
+        args = mod.argparse.Namespace(
+            aiot=["missing_aiot"],
+            ops_dir=ops_dir,
+            model="some_model",
+            xlsx=False,
+        )
+        result = mod._run_score_mode(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "missing_aiot" in captured.err
+        assert "operations.json" in captured.err
+
+    def test_explicit_aiot_with_existing_operations_json_succeeds(self, tmp_path: Path):
+        ops_dir = tmp_path / "ops"
+        gt_dir = tmp_path / "gt"
+        aiot = "0001234567"
+
+        self._make_ops_file(ops_dir / aiot)
+        self._make_gt_file(gt_dir / aiot)
+
+        args = mod.argparse.Namespace(
+            aiot=[aiot],
+            ops_dir=ops_dir,
+            model="some_model",
+            xlsx=False,
+        )
+
+        original_gt = mod._GROUND_TRUTH_DIR
+        mod._GROUND_TRUTH_DIR = gt_dir
+        try:
+            result = mod._run_score_mode(args)
+        finally:
+            mod._GROUND_TRUTH_DIR = original_gt
+
+        assert result == 0


### PR DESCRIPTION
Token usage reporting is now correctly implemented, addressing the issue where token counts were always reported as zero. The `_execute_model_call` function has been updated to extract token usage from the API response and increment the accumulated usage accordingly. Additionally, the evaluation script has been enhanced to automatically save detected operations to a JSON file, allowing for easier metric recalculation and inspection of results. A new CLI sub-command has been added to enable scoring from existing operations without invoking the LLM.

Fixes #134, Fixes #137, Fixes #145, Fixes #146, Fixes #147